### PR TITLE
add --no-tty option to gpg

### DIFF
--- a/cloudinit/gpg.py
+++ b/cloudinit/gpg.py
@@ -42,7 +42,7 @@ def recv_key(key, keyserver, retries=(1, 1)):
     @param retries: an iterable of sleep lengths for retries.
                     Use None to indicate no retries."""
     LOG.debug("Importing key '%s' from keyserver '%s'", key, keyserver)
-    cmd = ["gpg", "--keyserver=%s" % keyserver, "--recv-keys", key]
+    cmd = ["gpg", "--no-tty", "--keyserver=%s" % keyserver, "--recv-keys", key]
     if retries is None:
         retries = []
     trynum = 0


### PR DESCRIPTION
summary: fix error when gpg does not find "/dev/tty"

## Proposed Commit Message
fix error when gpg does not find "/dev/tty"
LP: #1813396

## Additional Context
see https://bugs.launchpad.net/cloud-init/+bug/1813396

## Test Steps
define an external keyserver such used for docker

```
apt:
  sources:
   docker:
     source: 'deb [arch=amd64] https://download.docker.com/linux/debian stretch stable'
     keyserver: keyserver.ubuntu.com
     keyid: 0EBFCD88
```


